### PR TITLE
feat: 错误模型分层并按阶段汇总失败

### DIFF
--- a/internal/decompile/decompile.go
+++ b/internal/decompile/decompile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jiaozhu/emorad/internal/cfr"
@@ -111,6 +112,15 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 			return err
 		}
 		color.Red("\n[ERROR] 处理失败: %v", err)
+		rpt.AddResult(report.Result{
+			ClassName: filepath.Base(inputPath),
+			FilePath:  inputPath,
+			Stage:     "process",
+			ErrorCode: "PROCESS_FAILED",
+			Success:   false,
+			Error:     err.Error(),
+			TimeStamp: time.Now(),
+		})
 		// 即使有错误也生成报告
 		rpt.Generate()
 		return err

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -157,6 +157,8 @@ func (p *ClassProcessor) Process(ctx context.Context, inputPath string, outputDi
 	result := report.Result{
 		ClassName:   filepath.Base(inputPath),
 		PackageName: ExtractPackageName(inputPath),
+		FilePath:    inputPath,
+		Stage:       "decompile",
 		Success:     false,
 		TimeStamp:   startTime,
 	}
@@ -164,6 +166,7 @@ func (p *ClassProcessor) Process(ctx context.Context, inputPath string, outputDi
 	err := p.cfrManager.Decompile(ctx, inputPath, outputDir)
 	if err != nil {
 		result.Success = false
+		result.ErrorCode = "DECOMPILE_FAILED"
 		result.Error = fmt.Sprintf("反编译失败: %v", err)
 		color.Red("✗ %s", result.ClassName)
 	} else {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -20,6 +20,9 @@ const consoleWidth = 80
 type Result struct {
 	ClassName   string    `json:"className"`
 	PackageName string    `json:"packageName"`
+	FilePath    string    `json:"filePath,omitempty"`
+	Stage       string    `json:"stage,omitempty"`
+	ErrorCode   string    `json:"errorCode,omitempty"`
 	Success     bool      `json:"success"`
 	Error       string    `json:"error,omitempty"`
 	TimeTaken   float64   `json:"timeTaken"`
@@ -28,27 +31,29 @@ type Result struct {
 
 // Report 表示整体反编译报告
 type Report struct {
-	InputPath     string     `json:"inputPath"`
-	OutputPath    string     `json:"outputPath"`
-	StartTime     time.Time  `json:"startTime"`
-	EndTime       time.Time  `json:"endTime"`
-	Status        string     `json:"status"`
-	TotalFiles    int32      `json:"totalFiles"`    // 已处理的文件数
-	ExpectedFiles int32      `json:"expectedFiles"` // 预期要处理的总文件数
-	SuccessCount  int32      `json:"successCount"`
-	FailureCount  int32      `json:"failureCount"`
-	Results       []Result   `json:"results"`
-	mu            sync.Mutex // 保护Results切片
+	InputPath     string         `json:"inputPath"`
+	OutputPath    string         `json:"outputPath"`
+	StartTime     time.Time      `json:"startTime"`
+	EndTime       time.Time      `json:"endTime"`
+	Status        string         `json:"status"`
+	TotalFiles    int32          `json:"totalFiles"`    // 已处理的文件数
+	ExpectedFiles int32          `json:"expectedFiles"` // 预期要处理的总文件数
+	SuccessCount  int32          `json:"successCount"`
+	FailureCount  int32          `json:"failureCount"`
+	StageFailures map[string]int `json:"stageFailures,omitempty"`
+	Results       []Result       `json:"results"`
+	mu            sync.Mutex     // 保护Results切片
 }
 
 // New 创建新的反编译报告
 func New(inputPath, outputPath string) *Report {
 	return &Report{
-		InputPath:  inputPath,
-		OutputPath: outputPath,
-		StartTime:  time.Now(),
-		Status:     "completed",
-		Results:    make([]Result, 0),
+		InputPath:     inputPath,
+		OutputPath:    outputPath,
+		StartTime:     time.Now(),
+		Status:        "completed",
+		StageFailures: make(map[string]int),
+		Results:       make([]Result, 0),
 	}
 }
 
@@ -94,9 +99,27 @@ func (r *Report) MarkCancelled() {
 	r.Status = "cancelled"
 }
 
+func (r *Report) rebuildStageFailures() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.StageFailures = make(map[string]int)
+	for _, it := range r.Results {
+		if it.Success {
+			continue
+		}
+		stage := it.Stage
+		if stage == "" {
+			stage = "unknown"
+		}
+		r.StageFailures[stage]++
+	}
+}
+
 // Generate 生成最终报告
 func (r *Report) Generate() error {
 	r.EndTime = time.Now()
+	r.rebuildStageFailures()
 	duration := r.EndTime.Sub(r.StartTime)
 	successCount := atomic.LoadInt32(&r.SuccessCount)
 	failureCount := atomic.LoadInt32(&r.FailureCount)
@@ -133,6 +156,14 @@ func (r *Report) Generate() error {
 		successCount,
 		failureCount,
 		getSuccessRate(successCount, totalFiles))
+
+	if len(r.StageFailures) > 0 {
+		fmt.Println("失败分布(按阶段):")
+		for stage, cnt := range r.StageFailures {
+			fmt.Printf("   - %s: %d\n", stage, cnt)
+		}
+		fmt.Println()
+	}
 
 	// 生成详细报告文件
 	if err := r.saveDetailedReports(); err != nil {
@@ -257,6 +288,8 @@ func (r *Report) saveHTMLReport(path string) error {
                         <tr>
                             <th>文件名</th>
                             <th>包名</th>
+                            <th>阶段</th>
+                            <th>错误码</th>
                             <th>状态</th>
                             <th>耗时(秒)</th>
                             <th>错误信息</th>
@@ -276,6 +309,14 @@ func (r *Report) saveHTMLReport(path string) error {
 		status := "success"
 		statusText := "成功"
 		errorMsg := "-"
+		stage := result.Stage
+		if stage == "" {
+			stage = "-"
+		}
+		errorCode := result.ErrorCode
+		if errorCode == "" {
+			errorCode = "-"
+		}
 		if !result.Success {
 			status = "failure"
 			statusText = "失败"
@@ -286,12 +327,16 @@ func (r *Report) saveHTMLReport(path string) error {
                         <tr>
                             <td>%s</td>
                             <td>%s</td>
+                            <td>%s</td>
+                            <td>%s</td>
                             <td><span class="status %s">%s</span></td>
                             <td>%.3f</td>
                             <td><div class="error-msg">%s</div></td>
                         </tr>`,
 			html.EscapeString(result.ClassName),
 			html.EscapeString(result.PackageName),
+			html.EscapeString(stage),
+			html.EscapeString(errorCode),
 			status,
 			statusText,
 			result.TimeTaken,


### PR DESCRIPTION
## 变更说明
本 PR 对应 #3。

### 已完成
- 扩展报告结果结构：新增 filePath / stage / errorCode
- 反编译失败统一打点 、
- 处理链路异常打点 、
- 报告新增 stageFailures 汇总（JSON）
- 终端摘要输出失败分布（按阶段）
- HTML 报告明细新增 阶段/错误码 列

### 验证
- go test ./... 通过

Closes #3