### PR TITLE
feat: 结构化日志与阶段耗时统计

### DIFF
--- a/cmd/emorad/main.go
+++ b/cmd/emorad/main.go
@@ -111,9 +111,11 @@ Without arguments, decompiles the current directory.`,
 			jarIncludeStr, _ := cmd.Flags().GetString("jar-include")
 			skipLibs, _ := cmd.Flags().GetBool("skip-libs")
 			noDefaultExclude, _ := cmd.Flags().GetBool("no-default-exclude")
+			logFormat, _ := cmd.Flags().GetString("log-format")
 
 			filterConfig := processor.NewDefaultFilterConfig()
 			filterConfig.SkipLibs = skipLibs
+			filterConfig.LogFormat = strings.ToLower(logFormat)
 			filterConfig.CopyResources, _ = cmd.Flags().GetBool("copy-resources")
 			filterConfig.CopyLibJars, _ = cmd.Flags().GetBool("copy-libs")
 			filterConfig.GenerateIDEA, _ = cmd.Flags().GetBool("idea-project")
@@ -140,6 +142,11 @@ Without arguments, decompiles the current directory.`,
 				}
 			}
 
+			if filterConfig.LogFormat != "text" && filterConfig.LogFormat != "json" {
+				color.Red("Error: --log-format must be text or json")
+				return
+			}
+
 			if err := decompile.Run(ctx, absInputPath, outputDir, workers, filterConfig); err != nil {
 				color.Red("Decompile failed: %v", err)
 				return
@@ -154,6 +161,7 @@ Without arguments, decompiles the current directory.`,
 	rootCmd.Flags().Bool("skip-libs", true, "Skip JAR files in lib directory")
 	rootCmd.Flags().Bool("no-default-exclude", false, "Disable default framework exclusion list")
 	rootCmd.Flags().StringP("jar-include", "j", "", "Only process lib JARs containing specified keywords")
+	rootCmd.Flags().String("log-format", "text", "Log format: text or json")
 	rootCmd.Flags().BoolP("copy-resources", "r", false, "Copy resource files to output/resources")
 	rootCmd.Flags().Bool("copy-libs", false, "Copy dependency JARs to output/libs")
 	rootCmd.Flags().Bool("idea-project", false, "Generate IDEA project structure with .iml file")

--- a/internal/decompile/decompile.go
+++ b/internal/decompile/decompile.go
@@ -2,10 +2,12 @@ package decompile
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/jiaozhu/emorad/internal/cfr"
@@ -13,9 +15,31 @@ import (
 	"github.com/jiaozhu/emorad/internal/report"
 )
 
+func logEvent(format string, level string, event string, kv map[string]any) {
+	if format == "json" {
+		payload := map[string]any{
+			"ts":    time.Now().Format(time.RFC3339),
+			"level": level,
+			"event": event,
+		}
+		for k, v := range kv {
+			payload[k] = v
+		}
+		b, _ := json.Marshal(payload)
+		fmt.Println(string(b))
+		return
+	}
+	if len(kv) == 0 {
+		fmt.Printf("[%s] %s\n", strings.ToUpper(level), event)
+		return
+	}
+	fmt.Printf("[%s] %s: %v\n", strings.ToUpper(level), event, kv)
+}
+
 // Run 执行反编译操作
 func Run(ctx context.Context, inputPath, outputDir string, workers int, filterConfig *processor.FilterConfig) error {
 
+	logEvent(filterConfig.LogFormat, "info", "start_decompile", map[string]any{"input": inputPath, "workers": workers})
 	color.Cyan("\n[START] 开始反编译...")
 	color.Cyan("============================================")
 
@@ -44,6 +68,7 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 
 	// 初始化CFR管理器
 	color.Cyan("[INIT] 初始化反编译器...")
+	initStart := time.Now()
 	cfrManager, err := cfr.NewManager()
 	if err != nil {
 		color.Red("[ERROR] 初始化CFR失败: %v", err)
@@ -73,6 +98,7 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 
 	// 创建报告
 	rpt := report.New(inputPath, srcDir)
+	rpt.AddStageDuration("init", time.Since(initStart).Seconds())
 
 	// 根据文件类型选择处理器
 	var proc processor.Processor
@@ -103,31 +129,40 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 	color.Cyan("============================================\n")
 
 	// 执行处理
+	processStart := time.Now()
 	if err := proc.Process(ctx, inputPath, srcDir, rpt); err != nil {
 		if err == context.Canceled || err == context.DeadlineExceeded {
 			color.Yellow("\n[CANCEL] 任务已中断: %v", err)
 			rpt.MarkCancelled()
+			rpt.AddStageDuration("process", time.Since(processStart).Seconds())
+			logEvent(filterConfig.LogFormat, "warn", "decompile_cancelled", map[string]any{"error": err.Error()})
 			_ = rpt.Generate()
 			return err
 		}
 		color.Red("\n[ERROR] 处理失败: %v", err)
+		rpt.AddStageDuration("process", time.Since(processStart).Seconds())
+		logEvent(filterConfig.LogFormat, "error", "decompile_failed", map[string]any{"error": err.Error()})
 		// 即使有错误也生成报告
 		rpt.Generate()
 		return err
 	}
+	rpt.AddStageDuration("process", time.Since(processStart).Seconds())
 
 	// Unicode 后处理：将 \uXXXX 转换为实际的中文字符
 	color.Cyan("\n[PROCESS] 处理 Unicode 转义序列...")
+	unicodeStart := time.Now()
 	processed, modified, err := processor.ProcessDirectoryUnicode(srcDir)
 	if err != nil {
 		color.Yellow("[WARN] Unicode 后处理警告: %v", err)
 	} else if modified > 0 {
 		color.Green("[OK] Unicode 后处理完成: 处理 %d 文件, 修复 %d 文件", processed, modified)
 	}
+	rpt.AddStageDuration("unicode_postprocess", time.Since(unicodeStart).Seconds())
 
 	// 生成 IDEA 项目配置
 	if filterConfig.GenerateIDEA {
 		color.Cyan("\n[PROCESS] 生成 IDEA 项目配置...")
+		ideaStart := time.Now()
 		projectName := filepath.Base(outputDir)
 		if projectName == "." || projectName == "" {
 			projectName = "decompiled"
@@ -145,8 +180,10 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 		} else {
 			color.Green("[OK] IDEA 项目配置已生成，可直接用 IDEA 打开: %s", outputDir)
 		}
+		rpt.AddStageDuration("idea_project", time.Since(ideaStart).Seconds())
 	}
 
+	logEvent(filterConfig.LogFormat, "info", "decompile_finished", map[string]any{"status": rpt.Status})
 	// 生成报告
 	return rpt.Generate()
 }

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -44,6 +44,7 @@ type FilterConfig struct {
 	Excludes      []string // 排除的包前缀
 	SkipLibs      bool     // 是否跳过 lib 目录下的 JAR
 	JarIncludes   []string // JAR 名称必须包含的关键字
+	LogFormat     string   // 日志格式: text/json
 	CopyResources bool     // 是否复制配置文件到输出目录
 	CopyLibJars   bool     // 是否复制依赖 JAR 到 libs 目录
 	GenerateIDEA  bool     // 是否生成 IDEA 项目配置
@@ -52,9 +53,10 @@ type FilterConfig struct {
 // NewDefaultFilterConfig 创建默认过滤配置
 func NewDefaultFilterConfig() *FilterConfig {
 	return &FilterConfig{
-		Includes: nil,
-		Excludes: DefaultExcludes,
-		SkipLibs: true,
+		Includes:  nil,
+		Excludes:  DefaultExcludes,
+		SkipLibs:  true,
+		LogFormat: "text",
 	}
 }
 

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -28,27 +28,29 @@ type Result struct {
 
 // Report 表示整体反编译报告
 type Report struct {
-	InputPath     string     `json:"inputPath"`
-	OutputPath    string     `json:"outputPath"`
-	StartTime     time.Time  `json:"startTime"`
-	EndTime       time.Time  `json:"endTime"`
-	Status        string     `json:"status"`
-	TotalFiles    int32      `json:"totalFiles"`    // 已处理的文件数
-	ExpectedFiles int32      `json:"expectedFiles"` // 预期要处理的总文件数
-	SuccessCount  int32      `json:"successCount"`
-	FailureCount  int32      `json:"failureCount"`
-	Results       []Result   `json:"results"`
-	mu            sync.Mutex // 保护Results切片
+	InputPath      string             `json:"inputPath"`
+	OutputPath     string             `json:"outputPath"`
+	StartTime      time.Time          `json:"startTime"`
+	EndTime        time.Time          `json:"endTime"`
+	Status         string             `json:"status"`
+	TotalFiles     int32              `json:"totalFiles"`    // 已处理的文件数
+	ExpectedFiles  int32              `json:"expectedFiles"` // 预期要处理的总文件数
+	SuccessCount   int32              `json:"successCount"`
+	FailureCount   int32              `json:"failureCount"`
+	StageDurations map[string]float64 `json:"stageDurations,omitempty"`
+	Results        []Result           `json:"results"`
+	mu             sync.Mutex         // 保护Results切片
 }
 
 // New 创建新的反编译报告
 func New(inputPath, outputPath string) *Report {
 	return &Report{
-		InputPath:  inputPath,
-		OutputPath: outputPath,
-		StartTime:  time.Now(),
-		Status:     "completed",
-		Results:    make([]Result, 0),
+		InputPath:      inputPath,
+		OutputPath:     outputPath,
+		StartTime:      time.Now(),
+		Status:         "completed",
+		StageDurations: make(map[string]float64),
+		Results:        make([]Result, 0),
 	}
 }
 
@@ -94,6 +96,12 @@ func (r *Report) MarkCancelled() {
 	r.Status = "cancelled"
 }
 
+func (r *Report) AddStageDuration(stage string, seconds float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.StageDurations[stage] = seconds
+}
+
 // Generate 生成最终报告
 func (r *Report) Generate() error {
 	r.EndTime = time.Now()
@@ -133,6 +141,14 @@ func (r *Report) Generate() error {
 		successCount,
 		failureCount,
 		getSuccessRate(successCount, totalFiles))
+
+	if len(r.StageDurations) > 0 {
+		fmt.Println("阶段耗时(秒):")
+		for stage, sec := range r.StageDurations {
+			fmt.Printf("   - %s: %.3f\n", stage, sec)
+		}
+		fmt.Println()
+	}
 
 	// 生成详细报告文件
 	if err := r.saveDetailedReports(); err != nil {


### PR DESCRIPTION
## 变更说明
本 PR 对应 #4。

### 已完成
- 新增 --log-format 参数，支持 text|json
- 新增结构化日志事件（start/finished/failed/cancelled）
- 报告新增 stageDurations 字段（JSON）
- 在控制台摘要输出阶段耗时分布
- 统计阶段包括：init / process / unicode_postprocess / idea_project

### 验证
- go test ./... 通过

Closes #4