### PR TITLE
feat: 支持依赖 JAR 前缀匹配反编译

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ emorad MyClass.class
 | `--workers` | `-w` | 并发工作器数量 | CPU核心数 |
 | `--include` | `-i` | 只处理匹配的包前缀，逗号分隔 | 无（处理所有） |
 | `--exclude` | `-e` | 排除匹配的包前缀，追加到默认列表 | 无 |
-| `--jar-include` | `-j` | 只处理名称包含指定关键字的 lib JAR | 无 |
+| `--jar-include` | `-j` | 只处理名称匹配指定关键字的 lib JAR | 无 |
+| `--jar-match-mode` | - | JAR 名称匹配模式：`contains`/`prefix` | `contains` |
 | `--copy-resources` | `-r` | 复制配置文件到 resources 目录 | `false` |
 | `--copy-libs` | - | 复制依赖 JAR 到 libs 目录 | `false` |
 | `--idea-project` | - | 生成 IDEA 项目结构（含 .iml 文件） | `false` |
@@ -123,6 +124,9 @@ emorad --no-default-exclude -e "org.springframework" app.jar
 ```bash
 # 只反编译名称包含 "myapp" 或 "common" 的 lib JAR
 emorad -j "myapp,common" app.jar
+
+# 按前缀匹配依赖 JAR（例如 user-service 开头）
+emorad -j "user-service" --jar-match-mode prefix app.jar
 
 # 结合包含过滤使用
 emorad -i "com.mycompany" -j "myapp" app.jar

--- a/cmd/emorad/main.go
+++ b/cmd/emorad/main.go
@@ -109,6 +109,7 @@ Without arguments, decompiles the current directory.`,
 			includeStr, _ := cmd.Flags().GetString("include")
 			excludeStr, _ := cmd.Flags().GetString("exclude")
 			jarIncludeStr, _ := cmd.Flags().GetString("jar-include")
+			jarMatchMode, _ := cmd.Flags().GetString("jar-match-mode")
 			skipLibs, _ := cmd.Flags().GetBool("skip-libs")
 			noDefaultExclude, _ := cmd.Flags().GetBool("no-default-exclude")
 			nestedJarStrategy, _ := cmd.Flags().GetString("nested-jar-strategy")
@@ -117,6 +118,7 @@ Without arguments, decompiles the current directory.`,
 
 			filterConfig := processor.NewDefaultFilterConfig()
 			filterConfig.SkipLibs = skipLibs
+			filterConfig.JarMatchMode = strings.ToLower(jarMatchMode)
 			filterConfig.NestedJarStrategy = nestedJarStrategy
 			filterConfig.MaxJarDepth = maxJarDepth
 			filterConfig.LogFormat = strings.ToLower(logFormat)
@@ -160,6 +162,10 @@ Without arguments, decompiles the current directory.`,
 				color.Red("Error: --log-format must be text or json")
 				return
 			}
+			if filterConfig.JarMatchMode != "contains" && filterConfig.JarMatchMode != "prefix" {
+				color.Red("Error: --jar-match-mode must be contains or prefix")
+				return
+			}
 
 			if err := decompile.Run(ctx, absInputPath, outputDir, workers, filterConfig); err != nil {
 				color.Red("Decompile failed: %v", err)
@@ -174,7 +180,8 @@ Without arguments, decompiles the current directory.`,
 	rootCmd.Flags().StringP("exclude", "e", "", "Exclude matching package prefixes, comma-separated")
 	rootCmd.Flags().Bool("skip-libs", true, "Skip JAR files in lib directory")
 	rootCmd.Flags().Bool("no-default-exclude", false, "Disable default framework exclusion list")
-	rootCmd.Flags().StringP("jar-include", "j", "", "Only process lib JARs containing specified keywords")
+	rootCmd.Flags().StringP("jar-include", "j", "", "Only process lib JARs matching specified keywords")
+	rootCmd.Flags().String("jar-match-mode", "contains", "JAR match mode: contains or prefix")
 	rootCmd.Flags().String("nested-jar-strategy", "filtered", "Nested JAR strategy: skip | filtered | full")
 	rootCmd.Flags().Int("max-jar-depth", 8, "Maximum nested JAR recursion depth")
 	rootCmd.Flags().String("log-format", "text", "Log format: text or json")

--- a/internal/decompile/decompile.go
+++ b/internal/decompile/decompile.go
@@ -54,7 +54,7 @@ func Run(ctx context.Context, inputPath, outputDir string, workers int, filterCo
 		color.Yellow("[CONFIG] 跳过依赖库: 已启用")
 	}
 	if len(filterConfig.JarIncludes) > 0 {
-		color.Green("[FILTER] JAR 名称过滤: %v", filterConfig.JarIncludes)
+		color.Green("[FILTER] JAR 名称过滤(%s): %v", filterConfig.JarMatchMode, filterConfig.JarIncludes)
 	}
 	color.Green("[CONFIG] 嵌套JAR策略: %s (max-depth=%d)", filterConfig.NestedJarStrategy, filterConfig.MaxJarDepth)
 	if filterConfig.CopyResources {

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -43,7 +43,8 @@ type FilterConfig struct {
 	Includes          []string // 包含的包前缀（优先级最高）
 	Excludes          []string // 排除的包前缀
 	SkipLibs          bool     // 是否跳过 lib 目录下的 JAR
-	JarIncludes       []string // JAR 名称必须包含的关键字
+	JarIncludes       []string // JAR 名称匹配关键字
+	JarMatchMode      string   // JAR匹配模式: contains/prefix
 	NestedJarStrategy string   // 嵌套JAR策略: skip/filtered/full
 	MaxJarDepth       int      // 嵌套JAR最大递归深度
 	LogFormat         string   // 日志格式: text/json
@@ -58,6 +59,7 @@ func NewDefaultFilterConfig() *FilterConfig {
 		Includes:          nil,
 		Excludes:          DefaultExcludes,
 		SkipLibs:          true,
+		JarMatchMode:      "contains",
 		NestedJarStrategy: "filtered",
 		MaxJarDepth:       8,
 		LogFormat:         "text",
@@ -87,30 +89,37 @@ func (f *FilterConfig) ShouldProcessClass(classPath, baseDir string) bool {
 	return true
 }
 
+func (f *FilterConfig) jarNameMatched(jarName string) bool {
+	if len(f.JarIncludes) == 0 {
+		return true
+	}
+	name := strings.ToLower(jarName)
+	mode := strings.ToLower(f.JarMatchMode)
+	for _, keyword := range f.JarIncludes {
+		k := strings.ToLower(keyword)
+		if mode == "prefix" {
+			if strings.HasPrefix(name, k) {
+				return true
+			}
+			continue
+		}
+		if strings.Contains(name, k) {
+			return true
+		}
+	}
+	return false
+}
+
 // ShouldProcessJar 判断是否应该处理该 JAR 文件
 func (f *FilterConfig) ShouldProcessJar(jarPath string) bool {
 	isLibJar := strings.Contains(jarPath, "BOOT-INF/lib") || strings.Contains(jarPath, "WEB-INF/lib")
 
 	if isLibJar {
 		if f.SkipLibs {
-			if len(f.JarIncludes) > 0 {
-				jarName := strings.ToLower(filepath.Base(jarPath))
-				for _, keyword := range f.JarIncludes {
-					if strings.Contains(jarName, strings.ToLower(keyword)) {
-						return true
-					}
-				}
-			}
-			return false
+			return f.jarNameMatched(filepath.Base(jarPath))
 		}
 		if len(f.JarIncludes) > 0 {
-			jarName := strings.ToLower(filepath.Base(jarPath))
-			for _, keyword := range f.JarIncludes {
-				if strings.Contains(jarName, strings.ToLower(keyword)) {
-					return true
-				}
-			}
-			return false
+			return f.jarNameMatched(filepath.Base(jarPath))
 		}
 	}
 	return true


### PR DESCRIPTION
## 变更说明
对应 #18。

### 新增能力
- 新增参数 --jar-match-mode，支持：contains / prefix
- 与 --jar-include 联动，可按前缀精准反编译依赖 JAR
- 示例：-j user-service --jar-match-mode prefix

### 兼容性
- 默认模式仍为 contains，保持原行为

### 文档
- README 参数表和示例已更新

### 验证
- go test ./... 通过

Closes #18